### PR TITLE
fix issue with turbolinks

### DIFF
--- a/vendor/assets/javascripts/sweet-alert.js
+++ b/vendor/assets/javascripts/sweet-alert.js
@@ -742,6 +742,9 @@
 			  });
 		  }
 	  }
+    $(document).on('page:change',function(){
+      window.sweetAlertInitialize();
+    });
   })();
 
 })(window, document);


### PR DESCRIPTION
fix sweetalert not work with turbolinks,  check my comment https://github.com/sharshenov/sweetalert-rails/issues/1. but this solution come with a pitfall. sweetalert don't require  jquery to work. but the turbolinks event need jquery to work. so after this pr, you need info this gem users to load sweetalert after jquery and jquery-ujs. case need the page:change event trigger to initialize sweetalert.
